### PR TITLE
Add Tables support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ObservationDims"
 uuid = "bd245535-7a0d-4808-be35-e2fe847ca032"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.2.0"
+version = "0.1.1"
 
 [deps]
 AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ObservationDims"
 uuid = "bd245535-7a0d-4808-be35-e2fe847ca032"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
 AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
@@ -10,16 +10,19 @@ Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NamedDims = "356022a1-0364-5f58-8944-0da4b18d706f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 AxisArrays = "0.4"
 Compat = "3.3"
 Distributions = "0.21, 0.22"
 NamedDims = "0.2"
+Tables = "1"
 julia = "1"
 
 [extras]
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test", "DataFrames"]

--- a/README.md
+++ b/README.md
@@ -54,13 +54,17 @@ When used with `NamedDimsArray`s and `AxisArray`s, the `obsdim` can also be a sy
 For `NamedDimsArray`s, the default `obsdim` is selected from `(:obs, :observations, :samples)` in order of preference.
 For example, `:obs` will always be selected if present, else `:observations` will selected if present, else `:samples` will be selected.
 If none of these are present you will be required to explicitly provide the `obsdim` yourself.
-This does not apply to `AxisArray`s, which default to `obsdim=1`.
+This does not apply to `AxisArray`s, which like `AbstractArray` in general, default to `obsdim=1`.
 
 ```julia
 # no fields are named :obs, :observations, or :samples
 arrange_obs(MatrixRowsOfObs(), named_dims; obsdim=:time)
 ```
 
+### Tables
+[Tables.jl](https://github.com/JuliaData/Tables.jl) tables, such as [DataFrames](https://github.com/JuliaData/DataFrames.jl/), are supported as an input.
+The observations for a table are always the rows, i.e. `obsdim=1` (warning will be given if you specify otherwise).
+The table will be converted into a matrix or iterator of vectors as appropriate.
 
 ## Method Traits
 

--- a/src/ObservationDims.jl
+++ b/src/ObservationDims.jl
@@ -141,7 +141,7 @@ end
 # Any -> SingleObs: never any need to rearrage
 organise_obs(::SingleObs, data; obsdim=nothing) = data
 
-# Tabhles support
+# Tables support
 function organise_obs(arrangement::IteratorOfObs, holder::_TableHolder; obsdim=1)
     _warn_about_table_obsdim(obsdim)
     data = holder.data

--- a/src/ObservationDims.jl
+++ b/src/ObservationDims.jl
@@ -68,9 +68,6 @@ Since tables do not have a type, wrap them in this so we can dispatch on them.
 struct _TableHolder{T}
     data::T
 end
-
-@inline _wrap_if_table(x) = Tables.istable(x) ? _TableHolder(x) : x
-
 """
     organise_obs(f, data; obsdim=nothing)
     organise_obs(::ObsArrangement, data; obsdim=nothing)
@@ -86,30 +83,32 @@ function organise_obs(f, data; obsdim=_default_obsdim(data))
     return organise_obs(obs_arrangement(f), data; obsdim=obsdim)
 end
 
-function organise_obs(arrangement::ObsArrangement, data; obsdim=_default_obsdim(data))
-    data = _wrap_if_table(data)
-    return _organise_obs(arrangement, data; obsdim=obsdim)
-end
-
 
 # Specify arrangement based on type of data:
 
 # Scalars have no "orientation" so no rearrangement required
 for T in (Sampleable, Number, Symbol)
-    @eval _organise_obs(::SingleObs, data::$T; obsdim=nothing) = data
-    @eval _organise_obs(::IteratorOfObs, data::$T; obsdim=nothing) = data
-    @eval _organise_obs(::ArraySlicesOfObs, data::$T; obsdim=nothing) = data
+    @eval organise_obs(::SingleObs, data::$T; obsdim=nothing) = data
+    @eval organise_obs(::IteratorOfObs, data::$T; obsdim=nothing) = data
+    @eval organise_obs(::ArraySlicesOfObs, data::$T; obsdim=nothing) = data
 end
 
 ## Vectors: obsdim is optional, we may or may not need it.
 for T in (Any, AbstractVector)
-
     # Iterator -> IteratorOfObs
-    @eval _organise_obs(::IteratorOfObs, obs_iter::$T; obsdim=nothing) = obs_iter
+    @eval function organise_obs(::IteratorOfObs, obs_iter::$T; obsdim=nothing)
+        if Tables.istable(obs_iter)
+            return organise_obs(IteratorOfObs(), _TableHolder(obs_iter); obsdim=obsdim)
+        else
+            return obs_iter
+        end
+    end
 
     # Iterator -> ArraySlicesOfObs
-    @eval function _organise_obs(::ArraySlicesOfObs{D}, obs_iter::$T; obsdim=nothing) where D
-
+    @eval function organise_obs(::ArraySlicesOfObs{D}, obs_iter::$T; obsdim=nothing) where D
+        if Tables.istable(obs_iter)
+            return organise_obs(ArraySlicesOfObs{D}(), _TableHolder(obs_iter); obsdim=obsdim)
+        end
         # we assume all obs have same number of dimensions else nothing makes sense
         ndims_per_obs = ndims(first(obs_iter))
 
@@ -140,49 +139,55 @@ end
 # Specify arrangement based on desired ObsArrangement:
 
 # Any -> SingleObs: never any need to rearrage
-_organise_obs(::SingleObs, data; obsdim=nothing) = data
+organise_obs(::SingleObs, data; obsdim=nothing) = data
 
 # Tabhles support
-function _organise_obs(arrangement::IteratorOfObs, holder::_TableHolder; obsdim=1)
-    obsdim !== 1 && (@warn "Arraying a Table, obsdim not equal to 1 ignored" obsdim)
+function organise_obs(arrangement::IteratorOfObs, holder::_TableHolder; obsdim=1)
+    _warn_about_table_obsdim(obsdim)
     data = holder.data
     return (collect(obs) for obs in Tables.rows(data))
 end
 
-function _organise_obs(arrangement::ArraySlicesOfObs, holder::_TableHolder; obsdim=1)
-    obsdim !== 1 && (@warn "Arraying a Table, obsdim not equal to 1 ignored" obsdim)
+function organise_obs(arrangement::ArraySlicesOfObs, holder::_TableHolder; obsdim=1)
+    _warn_about_table_obsdim(obsdim)
     data = Tables.matrix(holder.data)
-    return _organise_obs(arrangement, data, 1)
+    return organise_obs(arrangement, data; obsdim=1)
+end
+
+function _warn_about_table_obsdim(obsdim)
+    if obsdim !== 1 && obsdim !== nothing
+        @warn "Arraying a Table, obsdim not equal to 1 ignored" obsdim
+    end
 end
 
 # Array -> IteratorOfObs or ArraySlicesOfObs: depends on obsdim
 # Resorts to default obsdim which redispatches to the 3 arg form below.
 for A in (IteratorOfObs, ArraySlicesOfObs)
 
-    @eval function _organise_obs(arrangement::$A, data::AbstractArray; obsdim=_default_obsdim(data))
-        return _organise_obs(arrangement, data, obsdim)
+    @eval function organise_obs(arrangement::$A, data::AbstractArray; obsdim=_default_obsdim(data))
+        return organise_obs(arrangement, data, obsdim)
     end
 
-    @eval function _organise_obs(arrangement::$A, data::NamedDimsArray; obsdim=_default_obsdim(data))
+    @eval function organise_obs(arrangement::$A, data::NamedDimsArray; obsdim=_default_obsdim(data))
         obsdim = (obsdim isa Symbol) ? NamedDims.dim(data, obsdim) : obsdim
-        return _organise_obs(arrangement, data, obsdim)
+        return organise_obs(arrangement, data, obsdim)
     end
 
-    @eval function _organise_obs(arrangement::$A, data::AxisArray; obsdim=_default_obsdim(data))
+    @eval function organise_obs(arrangement::$A, data::AxisArray; obsdim=_default_obsdim(data))
         obsdim = (obsdim isa Symbol) ? axisdim(data, Axis{obsdim}) : obsdim
-        return _organise_obs(arrangement, data, obsdim)
+        return organise_obs(arrangement, data, obsdim)
     end
 end
 
 # 3 arg forms rearrange (non 1D) arrays according to the obsdim
 
 # Slice up the array to get an iterator of observations
-function _organise_obs(::IteratorOfObs, data::AbstractArray, obsdim::Integer)
+function organise_obs(::IteratorOfObs, data::AbstractArray, obsdim::Integer)
     return eachslice(data, dims=obsdim)
 end
 
 # Permute the array so the observations are arranged correctly
-function _organise_obs(
+function organise_obs(
     ::ArraySlicesOfObs{D}, data::AbstractArray{<:Any, N}, obsdim::Integer
 ) where {D, N}
 

--- a/src/ObservationDims.jl
+++ b/src/ObservationDims.jl
@@ -4,6 +4,7 @@ using AxisArrays
 using Compat
 using Distributions
 using NamedDims
+using Tables
 
 export obs_arrangement, organise_obs
 export SingleObs, IteratorOfObs, ArraySlicesOfObs
@@ -59,6 +60,18 @@ Specify the observation arrangement trait of a function `f`.
 function obs_arrangement end
 
 """
+    _TableHolder
+
+A internal wrapper type for dispatch purposes.
+Since tables do not have a type, wrap them in this so we can dispatch on them.
+"""
+struct _TableHolder{T}
+    data::T
+end
+
+@inline _wrap_if_table(x) = Tables.istable(x) ? _TableHolder(x) : x
+
+"""
     organise_obs(f, data; obsdim=nothing)
     organise_obs(::ObsArrangement, data; obsdim=nothing)
 
@@ -73,23 +86,29 @@ function organise_obs(f, data; obsdim=_default_obsdim(data))
     return organise_obs(obs_arrangement(f), data; obsdim=obsdim)
 end
 
+function organise_obs(arrangement::ObsArrangement, data; obsdim=_default_obsdim(data))
+    data = _wrap_if_table(data)
+    return _organise_obs(arrangement, data; obsdim=obsdim)
+end
+
+
 # Specify arrangement based on type of data:
 
 # Scalars have no "orientation" so no rearrangement required
 for T in (Sampleable, Number, Symbol)
-    @eval organise_obs(::SingleObs, data::$T; obsdim=nothing) = data
-    @eval organise_obs(::IteratorOfObs, data::$T; obsdim=nothing) = data
-    @eval organise_obs(::ArraySlicesOfObs, data::$T; obsdim=nothing) = data
+    @eval _organise_obs(::SingleObs, data::$T; obsdim=nothing) = data
+    @eval _organise_obs(::IteratorOfObs, data::$T; obsdim=nothing) = data
+    @eval _organise_obs(::ArraySlicesOfObs, data::$T; obsdim=nothing) = data
 end
 
 ## Vectors: obsdim is optional, we may or may not need it.
 for T in (Any, AbstractVector)
 
     # Iterator -> IteratorOfObs
-    @eval organise_obs(::IteratorOfObs, obs_iter::$T; obsdim=nothing) = obs_iter
+    @eval _organise_obs(::IteratorOfObs, obs_iter::$T; obsdim=nothing) = obs_iter
 
     # Iterator -> ArraySlicesOfObs
-    @eval function organise_obs(::ArraySlicesOfObs{D}, obs_iter::$T; obsdim=nothing) where D
+    @eval function _organise_obs(::ArraySlicesOfObs{D}, obs_iter::$T; obsdim=nothing) where D
 
         # we assume all obs have same number of dimensions else nothing makes sense
         ndims_per_obs = ndims(first(obs_iter))
@@ -121,36 +140,49 @@ end
 # Specify arrangement based on desired ObsArrangement:
 
 # Any -> SingleObs: never any need to rearrage
-organise_obs(::SingleObs, data; obsdim=nothing) = data
+_organise_obs(::SingleObs, data; obsdim=nothing) = data
+
+# Tabhles support
+function _organise_obs(arrangement::IteratorOfObs, holder::_TableHolder; obsdim=1)
+    obsdim !== 1 && (@warn "Arraying a Table, obsdim not equal to 1 ignored" obsdim)
+    data = holder.data
+    return (collect(obs) for obs in Tables.rows(data))
+end
+
+function _organise_obs(arrangement::ArraySlicesOfObs, holder::_TableHolder; obsdim=1)
+    obsdim !== 1 && (@warn "Arraying a Table, obsdim not equal to 1 ignored" obsdim)
+    data = Tables.matrix(holder.data)
+    return _organise_obs(arrangement, data, 1)
+end
 
 # Array -> IteratorOfObs or ArraySlicesOfObs: depends on obsdim
 # Resorts to default obsdim which redispatches to the 3 arg form below.
 for A in (IteratorOfObs, ArraySlicesOfObs)
 
-    @eval function organise_obs(arrangement::$A, data::AbstractArray; obsdim=_default_obsdim(data))
-        return organise_obs(arrangement, data, obsdim)
+    @eval function _organise_obs(arrangement::$A, data::AbstractArray; obsdim=_default_obsdim(data))
+        return _organise_obs(arrangement, data, obsdim)
     end
 
-    @eval function organise_obs(arrangement::$A, data::NamedDimsArray; obsdim=_default_obsdim(data))
+    @eval function _organise_obs(arrangement::$A, data::NamedDimsArray; obsdim=_default_obsdim(data))
         obsdim = (obsdim isa Symbol) ? NamedDims.dim(data, obsdim) : obsdim
-        return organise_obs(arrangement, data, obsdim)
+        return _organise_obs(arrangement, data, obsdim)
     end
 
-    @eval function organise_obs(arrangement::$A, data::AxisArray; obsdim=_default_obsdim(data))
+    @eval function _organise_obs(arrangement::$A, data::AxisArray; obsdim=_default_obsdim(data))
         obsdim = (obsdim isa Symbol) ? axisdim(data, Axis{obsdim}) : obsdim
-        return organise_obs(arrangement, data, obsdim)
+        return _organise_obs(arrangement, data, obsdim)
     end
 end
 
 # 3 arg forms rearrange (non 1D) arrays according to the obsdim
 
 # Slice up the array to get an iterator of observations
-function organise_obs(::IteratorOfObs, data::AbstractArray, obsdim::Integer)
+function _organise_obs(::IteratorOfObs, data::AbstractArray, obsdim::Integer)
     return eachslice(data, dims=obsdim)
 end
 
 # Permute the array so the observations are arranged correctly
-function organise_obs(
+function _organise_obs(
     ::ArraySlicesOfObs{D}, data::AbstractArray{<:Any, N}, obsdim::Integer
 ) where {D, N}
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,7 +33,7 @@ using Test
 
     @testset "organise_obs" begin
 
-        corganise_obs(args...; kwargs...) = collect(organise_obs(args...; kwargs...))
+        c_organise_obs(args...; kwargs...) = collect(organise_obs(args...; kwargs...))
 
         @testset "Simple Scalars" begin
             for (raw, arrange) in zip(
@@ -68,17 +68,17 @@ using Test
             )
                 for transform in (identity, Tuple, x->Base.Generator(identity, x))
                     raw = transform(out)
-                    @test out == corganise_obs(IteratorOfObs(), raw)
+                    @test out == c_organise_obs(IteratorOfObs(), raw)
                 end
             end
         end
 
         @testset "Simple IteratorOfObs for Vectors" begin
             raw = [1, 2, 3]
-            @test raw == corganise_obs(IteratorOfObs(), raw)
+            @test raw == c_organise_obs(IteratorOfObs(), raw)
 
             raw = 1:10
-            @test collect(raw) == corganise_obs(IteratorOfObs(), raw)
+            @test collect(raw) == c_organise_obs(IteratorOfObs(), raw)
         end
 
         @testset "Iterators to $Arrange" for (Arrange, out) in (
@@ -89,7 +89,7 @@ using Test
 
             for transform in (identity, Tuple, x->Base.Generator(identity, x))
                 data_iter = transform(raw)
-                @test out == corganise_obs(Arrange, data_iter)
+                @test out == c_organise_obs(Arrange, data_iter)
             end
         end
 
@@ -100,22 +100,22 @@ using Test
             (MatrixColsOfObs(), [1 4; 2 5; 3 6]),
         )
             raw = [1 2 3; 4 5 6]
-            @test out == corganise_obs(Arrange, raw)  # default is rows
-            @test out == corganise_obs(Arrange, raw; obsdim=1)
-            @test out == corganise_obs(Arrange, raw'; obsdim=2)
-            @test out == corganise_obs(Arrange, NamedDimsArray{(:obs, :var)}(raw))
-            @test out == corganise_obs(Arrange, NamedDimsArray{(:var, :obs)}(raw'))
-            @test out == corganise_obs(Arrange, NamedDimsArray{(:x, :y)}(raw'); obsdim=:y)
-            @test out == corganise_obs(Arrange, NamedDimsArray{(:x, :y)}(raw); obsdim=:x)
+            @test out == c_organise_obs(Arrange, raw)  # default is rows
+            @test out == c_organise_obs(Arrange, raw; obsdim=1)
+            @test out == c_organise_obs(Arrange, raw'; obsdim=2)
+            @test out == c_organise_obs(Arrange, NamedDimsArray{(:obs, :var)}(raw))
+            @test out == c_organise_obs(Arrange, NamedDimsArray{(:var, :obs)}(raw'))
+            @test out == c_organise_obs(Arrange, NamedDimsArray{(:x, :y)}(raw'); obsdim=:y)
+            @test out == c_organise_obs(Arrange, NamedDimsArray{(:x, :y)}(raw); obsdim=:x)
 
             A = AxisArray(raw, Axis{:y}([:t1, :t2]), Axis{:x}([:o1, :o2, :o3]))
-            @test out == corganise_obs(Arrange, A)
-            @test out == corganise_obs(Arrange, A; obsdim=1)
-            @test out == corganise_obs(Arrange, A; obsdim=:y)
+            @test out == c_organise_obs(Arrange, A)
+            @test out == c_organise_obs(Arrange, A; obsdim=1)
+            @test out == c_organise_obs(Arrange, A; obsdim=:y)
 
             A = AxisArray(raw', Axis{:x}([:o1, :o2, :o3]), Axis{:y}([:t1, :t2]))
-            @test out == corganise_obs(Arrange, A; obsdim=2)
-            @test out == corganise_obs(Arrange, A; obsdim=:y)
+            @test out == c_organise_obs(Arrange, A; obsdim=2)
+            @test out == c_organise_obs(Arrange, A; obsdim=:y)
 
         end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,7 +33,7 @@ using Test
 
     @testset "organise_obs" begin
 
-        c_organise_obs(args...; kwargs...) = collect(organise_obs(args...; kwargs...))
+        corganise_obs(args...; kwargs...) = collect(organise_obs(args...; kwargs...))
 
         @testset "Simple Scalars" begin
             for (raw, arrange) in zip(
@@ -68,17 +68,17 @@ using Test
             )
                 for transform in (identity, Tuple, x->Base.Generator(identity, x))
                     raw = transform(out)
-                    @test out == c_organise_obs(IteratorOfObs(), raw)
+                    @test out == corganise_obs(IteratorOfObs(), raw)
                 end
             end
         end
 
         @testset "Simple IteratorOfObs for Vectors" begin
             raw = [1, 2, 3]
-            @test raw == c_organise_obs(IteratorOfObs(), raw)
+            @test raw == corganise_obs(IteratorOfObs(), raw)
 
             raw = 1:10
-            @test collect(raw) == c_organise_obs(IteratorOfObs(), raw)
+            @test collect(raw) == corganise_obs(IteratorOfObs(), raw)
         end
 
         @testset "Iterators to $Arrange" for (Arrange, out) in (
@@ -89,7 +89,7 @@ using Test
 
             for transform in (identity, Tuple, x->Base.Generator(identity, x))
                 data_iter = transform(raw)
-                @test out == c_organise_obs(Arrange, data_iter)
+                @test out == corganise_obs(Arrange, data_iter)
             end
         end
 
@@ -100,22 +100,22 @@ using Test
             (MatrixColsOfObs(), [1 4; 2 5; 3 6]),
         )
             raw = [1 2 3; 4 5 6]
-            @test out == c_organise_obs(Arrange, raw)  # default is rows
-            @test out == c_organise_obs(Arrange, raw; obsdim=1)
-            @test out == c_organise_obs(Arrange, raw'; obsdim=2)
-            @test out == c_organise_obs(Arrange, NamedDimsArray{(:obs, :var)}(raw))
-            @test out == c_organise_obs(Arrange, NamedDimsArray{(:var, :obs)}(raw'))
-            @test out == c_organise_obs(Arrange, NamedDimsArray{(:x, :y)}(raw'); obsdim=:y)
-            @test out == c_organise_obs(Arrange, NamedDimsArray{(:x, :y)}(raw); obsdim=:x)
+            @test out == corganise_obs(Arrange, raw)  # default is rows
+            @test out == corganise_obs(Arrange, raw; obsdim=1)
+            @test out == corganise_obs(Arrange, raw'; obsdim=2)
+            @test out == corganise_obs(Arrange, NamedDimsArray{(:obs, :var)}(raw))
+            @test out == corganise_obs(Arrange, NamedDimsArray{(:var, :obs)}(raw'))
+            @test out == corganise_obs(Arrange, NamedDimsArray{(:x, :y)}(raw'); obsdim=:y)
+            @test out == corganise_obs(Arrange, NamedDimsArray{(:x, :y)}(raw); obsdim=:x)
 
             A = AxisArray(raw, Axis{:y}([:t1, :t2]), Axis{:x}([:o1, :o2, :o3]))
-            @test out == c_organise_obs(Arrange, A)
-            @test out == c_organise_obs(Arrange, A; obsdim=1)
-            @test out == c_organise_obs(Arrange, A; obsdim=:y)
+            @test out == corganise_obs(Arrange, A)
+            @test out == corganise_obs(Arrange, A; obsdim=1)
+            @test out == corganise_obs(Arrange, A; obsdim=:y)
 
             A = AxisArray(raw', Axis{:x}([:o1, :o2, :o3]), Axis{:y}([:t1, :t2]))
-            @test out == c_organise_obs(Arrange, A; obsdim=2)
-            @test out == c_organise_obs(Arrange, A; obsdim=:y)
+            @test out == corganise_obs(Arrange, A; obsdim=2)
+            @test out == corganise_obs(Arrange, A; obsdim=:y)
 
         end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using ObservationDims
 using AxisArrays
 using Distributions
+using DataFrames
 using LinearAlgebra
 using NamedDims
 using Random
@@ -155,4 +156,21 @@ using Test
 
     end
 
+    @testset "Tables.jl support" begin
+        nt_table = [(a=1, b=2, c=3), (a=10, b=20, c=30)]  # basic row table
+        df = DataFrame(nt_table)  # advanced column table
+
+        @testset "$(typeof(table))" for table in (df, nt_table)
+            @test collect(organise_obs(IteratorOfObs(), table)) == [[1, 2, 3], [10, 20, 30]]
+            @test organise_obs(MatrixRowsOfObs(), table) == [1 2 3; 10 20 30]
+            @test organise_obs(MatrixColsOfObs(), table) == [1 10; 2 20; 3 30]
+
+            for arrangement in (MatrixColsOfObs(), MatrixRowsOfObs(), IteratorOfObs())
+                @test_logs(
+                    (:warn, r"obsdim not equal to 1"),
+                    organise_obs(arrangement, table; obsdim=20)
+                )
+            end
+        end
+    end
 end


### PR DESCRIPTION
This closes #14 

An issue is, because Table is not a type can't dispatch on it.
so we wrap it in a `_TableHolder` for dispatch purposes.

One assumption this code makes is that a a table is never a AbstractMatrix.
Or rather that if it is, it should be treated using Matrix behavour, rather than Table behavour.
I think that is sound.