### PR TITLE
Remove direct dependency on AxisArrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,9 @@
 name = "ObservationDims"
 uuid = "bd245535-7a0d-4808-be35-e2fe847ca032"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.6"
+version = "0.1.7"
 
 [deps]
-AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -21,8 +20,9 @@ Tables = "1"
 julia = "1"
 
 [extras]
+AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "DataFrames"]
+test = ["AxisArrays", "Test", "DataFrames"]

--- a/src/ObservationDims.jl
+++ b/src/ObservationDims.jl
@@ -164,7 +164,7 @@ end
 for A in (IteratorOfObs, ArraySlicesOfObs)
 
     @eval function organise_obs(arrangement::$A, data::AbstractArray; obsdim=_default_obsdim(data))
-        if obsdim isa Symbol && hasproperty(data, :axes)
+        if obsdim isa Symbol && hasproperty(data, :axes)  # support AxisArrays via structural ducktyping
             obsdim = findfirst(x -> in(obsdim, typeof(x).parameters), data.axes)
         end
         return organise_obs(arrangement, data, obsdim)

--- a/src/ObservationDims.jl
+++ b/src/ObservationDims.jl
@@ -1,6 +1,5 @@
 module ObservationDims
 
-using AxisArrays
 using Compat: eachslice
 using Distributions
 using NamedDims
@@ -165,16 +164,14 @@ end
 for A in (IteratorOfObs, ArraySlicesOfObs)
 
     @eval function organise_obs(arrangement::$A, data::AbstractArray; obsdim=_default_obsdim(data))
+        if obsdim isa Symbol && hasproperty(data, :axes)
+            obsdim = findfirst(x -> in(obsdim, typeof(x).parameters), data.axes)
+        end
         return organise_obs(arrangement, data, obsdim)
     end
 
     @eval function organise_obs(arrangement::$A, data::NamedDimsArray; obsdim=_default_obsdim(data))
         obsdim = (obsdim isa Symbol) ? NamedDims.dim(data, obsdim) : obsdim
-        return organise_obs(arrangement, data, obsdim)
-    end
-
-    @eval function organise_obs(arrangement::$A, data::AxisArray; obsdim=_default_obsdim(data))
-        obsdim = (obsdim isa Symbol) ? axisdim(data, Axis{obsdim}) : obsdim
         return organise_obs(arrangement, data, obsdim)
     end
 end


### PR DESCRIPTION
Related to https://github.com/invenia/ObservationDims.jl/issues/3

Draft status as I want to discuss the below first and then implement the same solution for NamedDims.

There are 3 ways we can do this:
1. Keep things as they are - we don't seem to be adding new types too often, but it means downstream dependencies implicitly depend on AxisArrays.jl. This is no longer the ideal as we want to remove AxisArrays as a dependency in our internal packages.
2. Implicitly support AxisArrays / NamedDims by way of a hacky "duck-typing" (this PR). This is non-breaking and removes the dependency, but it makes the code more complicated than it needs to be and doesn't fully satisfy https://github.com/invenia/ObservationDims.jl/issues/3.
3. Let AxisArrays / NamedDims.jl directly support ObservationDims.jl as https://github.com/invenia/ObservationDims.jl/issues/3 suggests. This is probably easier to do now than it previously was since we're dropping AxisArrays anyway, and it's easier for us to make the necessary changes to NamedDims.jl (and AxisKeys.jl if we wanted). 