### PR TITLE
Import hasproperty from Compat.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ObservationDims"
 uuid = "bd245535-7a0d-4808-be35-e2fe847ca032"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.7"
+version = "0.1.8"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/ObservationDims.jl
+++ b/src/ObservationDims.jl
@@ -1,6 +1,6 @@
 module ObservationDims
 
-using Compat: eachslice
+using Compat: eachslice, hasproperty
 using Distributions
 using NamedDims
 using Tables


### PR DESCRIPTION
Didn't realise nightly was failing on 1.0 since the last release due to this.

https://github.com/invenia/ObservationDims.jl/actions/workflows/CI.yml

